### PR TITLE
fix: add extensions to module imports

### DIFF
--- a/src/async.ts
+++ b/src/async.ts
@@ -1,4 +1,4 @@
-import { Maybe } from './maybe';
+import { Maybe } from './maybe.js';
 
 /**
  * An abstract box representing asynchronous value state.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { Async } from './async';
-export { Maybe } from './maybe';
-export { Result } from './result';
+export { Async } from './async.js';
+export { Maybe } from './maybe.js';
+export { Result } from './result.js';

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,4 +1,4 @@
-import { Maybe } from './maybe';
+import { Maybe } from './maybe.js';
 
 /**
  * An abstract box representing success or failure.


### PR DESCRIPTION
This should allow it to be used directly from Node.js, for example